### PR TITLE
updated alpine to 3.8

### DIFF
--- a/appliance/alpine/Dockerfile
+++ b/appliance/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM	alpine:3.7
+FROM	alpine:3.8
 LABEL   maintainer="rgerhards@adiscon.com"
 COPY	rsyslog@lists.adiscon.com-5a55e598.rsa.pub /etc/apk/keys/rsyslog@lists.adiscon.com-5a55e598.rsa.pub
 RUN	echo "http://alpine.rsyslog.com/3.7/stable" >> /etc/apk/repositories \


### PR DESCRIPTION
updating alpine to 3.8 as 3.9 breaks the rsyslog config file.