### PR TITLE
compile civetweb with '-DREENTRANT_TIME'

### DIFF
--- a/dev_env/ubuntu/base/18.04/Dockerfile
+++ b/dev_env/ubuntu/base/18.04/Dockerfile
@@ -199,7 +199,7 @@ RUN	cd helper-projects \
 RUN	cd helper-projects && \
 	git clone https://github.com/civetweb/civetweb.git \
 	&& cd civetweb \
-	&& (unset CFLAGS; make -j build ; make install-headers ; make install-slib ) \
+	&& (unset CFLAGS; make -j build COPT="-DREENTRANT_TIME"; make install-headers ; make install-slib ) \
 	&& cd .. \
 	&& rm -rf civetweb
 


### PR DESCRIPTION
Directs Civetweb to use gmtime_r instead of gmtime.
Appears to be needed in order to fix imhttp tests for ubuntu TSAN CI built with clang