### PR TITLE
Fixed fedora 36 build for RHEL support

### DIFF
--- a/dev_env/fedora/pkg_base/36/Dockerfile
+++ b/dev_env/fedora/pkg_base/36/Dockerfile
@@ -1,6 +1,7 @@
 FROM	fedora:36
 RUN	dnf -y update
-RUN	dnf -y install wget mock git sudo mc vim screen rsync createrepo rpm-sign yum
+RUN	dnf -y install wget mock git sudo mc vim screen rsync createrepo rpm-sign yum crypto-policies-scripts.noarch
+RUN	update-crypto-policies --set LEGACY
 RUN	mkdir /private-files
 VOLUME	/private-files
 RUN	useradd pkg --uid 1001 -ms /bin/bash

--- a/dev_env/fedora/pkg_base/36/extra/initenv.sh
+++ b/dev_env/fedora/pkg_base/36/extra/initenv.sh
@@ -18,24 +18,26 @@ cp -rf /private-files/.gnupg /home/pkg/.gnupg/
 cp -rf /private-files/.gnupg/* /home/pkg/.gnupg/
 cp -rf /private-files/.gnupg /root/.gnupg/
 cp -rf /private-files/.gnupg/* /root/.gnupg/
-cp -rf /private-files/.ssh /root/.ssh/
-cp -rf /private-files/.ssh/* /root/.ssh/
-cp -rf /private-files/.ssh /home/pkg/.ssh/
-cp -rf /private-files/.ssh/* /home/pkg/.ssh/
+cp -rf /private-files/.ssh /root/
+cp -rf /private-files/.ssh /home/pkg/
 # Copy entitlements and subscription manager configurations
-cp -rf /home/pkg/private/mount/rhel/etc-pki-entitlement /etc/pki/entitlement
-cp -rf /home/pkg/private/mount/rhel/rhsm-conf /etc/rhsm
-cp -rf /home/pkg/private/mount/rhel/rhsm-ca /etc/rhsm/ca
+cp -rf /private-files/rhel/etc-pki-entitlement/* /etc/pki/entitlement/
+cp -rf /private-files/rhel/rhsm-conf /etc/rhsm/
+cp -rf /private-files/rhel/rhsm-ca /etc/rhsm/ca/
 echo "---------------------------------------------"
 
 echo "--------------------------------"
 echo "--- Setting file permissions ---"
 chmod -R 600 /home/pkg/.gnupg/
 chmod -R 600 /root/.gnupg/
-chown pkg:pkg /private-files/* 
+chown pkg:pkg /private-files/*
 chown pkg:pkg /private-files/.*
-chmod -R 0600 /private-files/.ssh/id_rsa 
-
+chmod -R 0600 /private-files/.ssh/id_rsa
+chmod -R 0600 /private-files/.ssh/id_dsa
+chmod -R 0600 /home/pkg/.ssh/id_rsa
+chmod -R 0600 /home/pkg/.ssh/id_dsa
+chmod -R 0600 /root/.ssh/id_rsa
+chmod -R 0600 /root/.ssh/id_dsa
 echo "--------------------------------"
 
 echo "--------------------------------"

--- a/dev_env/fedora/pkg_buildbot/36/Dockerfile
+++ b/dev_env/fedora/pkg_buildbot/36/Dockerfile
@@ -1,23 +1,22 @@
 FROM rsyslog/rsyslog_dev_pkg_base_fedora:36
 USER root
-#RUN dnf -y --allowerasing install fedora-release
 RUN dnf -y install  \
-   python-devel \
-   python-pip
-RUN pip install buildbot-worker buildbot-slave
+   python3-devel \
+   python3-pip
+RUN pip3 install buildbot-worker buildbot-slave
 RUN groupadd -r buildbot && useradd -r -g buildbot buildbot
 RUN mkdir /worker && chown buildbot:buildbot /worker
 # Install your build-dependencies here ...
 ENV WORKER_ENVIRONMENT_BLACKLIST=WORKER*
-USER root
-#USER buildbot
+#USER root
+USER buildbot
 WORKDIR /worker
 RUN buildbot-worker create-worker . docker.rsyslog.com docker-fedora36 password
 # the following script is directly from buildbot git repo and seems
 # to be necessary at the moment.
 # see https://github.com/buildbot/buildbot/issues/4179
 COPY tpl-buildbot.tac /worker/buildbot.tac
-ENTRYPOINT ["/usr/bin/buildbot-worker"]
+ENTRYPOINT ["/usr/local/bin/buildbot-worker"]
 CMD ["start", "--nodaemon"]
 VOLUME /worker
 USER root


### PR DESCRIPTION
- Fix RHEL entitlements copy
- use legacy crypto-policies in fedora36 to regain pubkey auth
- Fix permission for private keys in initenv.sh
- build and pushed rsyslog/rsyslog_dev_pkg_buildbot_fedora:36 and rsyslog/rsyslog_dev_pkg_base_fedora:36