### PR TITLE
Add note to readme about hostname templates with cluster loadbalancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ To start from scratch, do
 
 * **Remember to periodically apply (security) updates to the docker
   images!**
+
+### Usage Notes
+
+* Hostname Templates - If you run this in a cluster environment with load balancing or any other networking layer that may hide or change the client IP address, you may need to configure your cluster service that exposes rsyslog to ensure that the actual client IP address makes it through to rsyslog.


### PR DESCRIPTION
Added section for "Usage Notes" and a bullet about hostname templates and specific changes that may be required to ensure the client IP makes it to rsyslog.