### PR TITLE
Add ulimit workarround into pkg_base fedora 36 container

### DIFF
--- a/dev_env/fedora/pkg_base/36/Dockerfile
+++ b/dev_env/fedora/pkg_base/36/Dockerfile
@@ -1,4 +1,11 @@
 FROM	fedora:36
+# Workarround for a bug affecting buildkit with yum when ulimit is unlimited
+# https://github.com/docker/buildx/issues/379#issuecomment-1196517905
+RUN echo "* soft nofile 1024000" >> /etc/security/limits.conf && \
+    echo "* hard nofile 1024000" >> /etc/security/limits.conf && \
+    echo "session required pam_limits.so" >> /etc/pam.d/common-session && \
+    echo "ulimit -n 1024000" >> /etc/profile.d/ulimit.sh
+# Install packages
 RUN	dnf -y update
 RUN	dnf -y install wget mock git sudo mc vim screen rsync createrepo rpm-sign yum crypto-policies-scripts.noarch
 RUN	update-crypto-policies --set LEGACY


### PR DESCRIPTION
Fixes a slow cpu issue related to yum run by mock inside a docker container. See also: https://github.com/docker/buildx/issues/379#issuecomment-1196517905

closes: https://github.com/rsyslog/rsyslog-docker/issues/66