### PR TITLE
Update README history and deprecate legacy images

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,25 @@ see also https://github.com/rsyslog/rsyslog/projects/5
 
 The docker effort currently uses multiple containers.
 
-# Alpine Linux
-We intend to use alpine linux for the logging appliance container, because
-it is small, secure and relatively recently.
+## Repository Overview
+This repository contains various experimental Dockerfiles for building rsyslog containers.
+
+* `/appliance` - an early experiment at a logging appliance. This approach did not work out and the images are outdated. The files are kept for reference only and should not be used.
+* `/dev_env` - build environments used for rsyslog CI testing. They contain every dependency and are several gigabytes in size. These images are meant for contributors, not general public use.
+* We are working on new images intended for general users. They will include minimal, standard and role-based variants (e.g. collector or docker). It is undecided whether these will replace `/base` or live under a new `/user` directory.
+* Legacy Alpine and CentOS base images remain in `/base` for reference but are no longer maintained.
+
+## Ubuntu Base
+Development now focuses on Ubuntu images which integrate best with our daily stable package builds. Alpine and CentOS containers are no longer produced.
+
+## History
+### CentOS Notes
+Older CentOS 7 definitions can be found under `/base/centos7`. Like the Alpine files, these are no longer maintained but remain for reference.
+### Historical: Alpine Linux
+The following notes describe the original Alpine based build process. These images are no longer built.
+For those interested, the old packaging repository is still available at
+https://github.com/rgerhards/alpine-rsyslog-extras.
+We intended to use Alpine Linux for the logging appliance container because it is small and secure.
 
 Right now, alpine misses some components that we need. So we build some
 packages ourself. This will most probably be an ongoing activity as

--- a/appliance/README.md
+++ b/appliance/README.md
@@ -1,20 +1,12 @@
-**EXPERIMENTAL** docker containter to run rsyslog
+**DEPRECATED**
 
-This aims at providing a full-functional docker container with ample features.
-Right now, it is under development. We welcome checking out and commenting it,
-but **do not use it in production**.
+This directory contains an early experiment to provide a full-featured rsyslog
+logging appliance. The approach ultimately did not work out and the resulting
+images are heavily outdated. The files are kept for reference only and are
+**not** recommended for production use.
 
-This provides two containers:
-- alpine based, this is what you want in production
-- ubuntu based, this is primarily for rsyslog developers
+The experiment provided two Dockerfiles:
+- Alpine based
+- Ubuntu based
 
-more info:
-- https://github.com/rsyslog/rsyslog/issues/2368
-- https://github.com/rsyslog/rsyslog/projects/5
-
-## projects that provide docker containers:
-
-- https://github.com/deoren/rsyslog-docker (based on @halfer provided files)
-- https://github.com/megastef/rsyslog-logsene (logsene-enabled)
-- https://github.com/camptocamp/docker-rsyslog-bin/blob/master/Dockerfile (Ubunut xenial)
-- https://github.com/jumanjihouse/docker-rsyslog (Alpine Linux)
+For current container efforts please refer to the project root README.

--- a/appliance/alpine/README.md
+++ b/appliance/alpine/README.md
@@ -1,3 +1,5 @@
+**Deprecated** - This directory contains the original Alpine-based appliance and is kept for reference only.
+
 ## Configuring the syslog appliance
 
 ### Files

--- a/appliance/ubuntu/README.md
+++ b/appliance/ubuntu/README.md
@@ -1,13 +1,4 @@
-Note: we currently focus on the Alpine container, because
+**Deprecated**
 
-- Alpine is frequently used in docker due to the small footprint
-- We have a firm grip on Alpine packaging and can quickly build
-  ourselfs all components that we need (quick turn-around cycle)
-- the appliance container is not yet mature, so duplicating work
-  sounds counter-productive
-
-Once the Alpine container is really production grade and if there is
-demand for others, we plan to create appliances with other base OS.
-Ubuntu and CentOS would be choices.
-
-see also: https://github.com/rsyslog/rsyslog-docker/issues/3
+This directory was part of the early appliance experiment and is no longer maintained.
+For current container efforts see the repository root README.

--- a/base/alpine/README.md
+++ b/base/alpine/README.md
@@ -1,12 +1,7 @@
 ## rsyslog base container for Alpine
 
-This container just provides a fresh rsyslog with frequently used
-modules on top of Alpine.
+**Deprecated**
 
-Use this, if you
+This image provides rsyslog with a small set of frequently used modules on top of Alpine Linux and was originally meant as a building block for custom containers.
 
-a) want to build your own container based on current rsyslog
-b) want to run rsyslog with a custom config by you
-
-note that in case b) you need to make sure that you use volumes
-etc properly. No specific support for this has been added.
+Development has moved to Ubuntu-based images to better integrate with our daily stable packages. Alpine files are kept only for historical reference.

--- a/base/centos7/README.md
+++ b/base/centos7/README.md
@@ -1,15 +1,7 @@
 ## rsyslog base container for CentOS 7
 
-This container just provides a fresh rsyslog with frequently used
-modules on top of CentOS 7.
+**Deprecated**
 
-Use this, if you
+This image supplies rsyslog with common modules on CentOS 7 and was mainly intended as a base for specialized containers.
 
-a) want to build your own container based on current rsyslog
-b) want to run rsyslog with a custom config by you
-c) want to run a client machine where rsyslog processes log messages
-   (the default CentOS 7 config does NOT work inside a container, but
-   this container has a corrected config!)
-
-note that in case b) you need to make sure that you use volumes
-etc properly. No specific support for this has been added.
+We now focus on Ubuntu-based images for better package integration. The CentOS files are preserved only for historical reference.

--- a/dev_env/README.md
+++ b/dev_env/README.md
@@ -1,0 +1,4 @@
+These images are used for rsyslog CI and development testing. Each contains all
+build dependencies so that the full feature set can be exercised. They are
+large (1-3 GB) and not intended for general production use. Developers working
+on rsyslog may use them to reproduce the CI environment.


### PR DESCRIPTION
## Summary
- mention Alpine and CentOS images are legacy
- explain that development now centers on Ubuntu
- mark old appliance docs as deprecated
- note deprecation in base image READMEs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840abddeb448332977eadc1c1c16a63