### PR TITLE
Add .dockerignore files for rsyslog variants

### DIFF
--- a/rsyslog/collector/.dockerignore
+++ b/rsyslog/collector/.dockerignore
@@ -1,0 +1,5 @@
+*.sw?
+tmp*
+run
+build.sh
+README*

--- a/rsyslog/dockerlogs/.dockerignore
+++ b/rsyslog/dockerlogs/.dockerignore
@@ -1,0 +1,5 @@
+*.sw?
+tmp*
+run
+build.sh
+README*

--- a/rsyslog/standard/.dockerignore
+++ b/rsyslog/standard/.dockerignore
@@ -1,0 +1,5 @@
+*.sw?
+tmp*
+run
+build.sh
+README*


### PR DESCRIPTION
## Summary
- add `.dockerignore` files under `rsyslog/standard`, `collector` and `dockerlogs`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841e7eed9f48332863d8c9bc3de767e