### PR TITLE
Add brief READMEs for image variants

### DIFF
--- a/rsyslog/dockerlogs/README.md
+++ b/rsyslog/dockerlogs/README.md
@@ -1,0 +1,5 @@
+## rsyslog official container for Docker logs
+
+This variant contains the `imdocker` module and configuration to collect logs from the Docker daemon and containers.
+
+See the [main README](../../README.md) for usage and build details.

--- a/rsyslog/host/README.md
+++ b/rsyslog/host/README.md
@@ -1,0 +1,5 @@
+## rsyslog container for forwarding host logs
+
+This configuration is meant for a container that ships logs from the local host to a remote collector using rsyslog.
+
+See the [main README](../../README.md) for an overview of all images and build instructions.

--- a/rsyslog/standard/README.md
+++ b/rsyslog/standard/README.md
@@ -1,0 +1,5 @@
+## rsyslog official standard container
+
+This image builds on the minimal variant and includes commonly used rsyslog modules for a balanced default setup.
+
+See the [main README](../../README.md) for build instructions and details on the image variants.


### PR DESCRIPTION
## Summary
- document the purpose of the standard image
- document the dockerlogs variant
- describe the host-forwarding configuration

## Testing
- `make -C rsyslog help`

------
https://chatgpt.com/codex/tasks/task_e_6841e7e4fac88332bceaf840e6b111c2